### PR TITLE
35 bug active link style

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ react - `18.2.0`<p>
 - I wanted image gallery to be a bit more lively than 'Monk' gallery. That's why text magically appears when you hover over the images!
 
 </details>
+
+<details><summary>[BUG] active link style #35</summary>
+
+<sub><sup>[[BUG] active link style #35](https://github.com/wongprom/test-next-13/issues/35)</sup></sub>
+
+### The Fantastic Journey to Cleaner Code! 🧹
+
+- Behold the creation of a superhero component that parent components can now effortlessly map out! Adding new links and routes? Piece of cake! 🍰
+
+### Sprucing Up with Style! 💃
+
+- When it comes to those delightful sublinks emerging from `/about`, we're giving the page a makeover that's cleaner than a freshly laundered superhero cape. What does that mean? We're keeping it as simple as a sidekick's sidekick until we've decided on our grand style and layout reveal! Stay tuned for the fashion show!
+</details>

--- a/app/about/adept/page.tsx
+++ b/app/about/adept/page.tsx
@@ -16,7 +16,7 @@ type ListType = {
 const Page = () => {
   const [list, setList] = useState<ListType[]>(characterTestADEPT15);
   return (
-    <div className="bg-[#f2f2f2] h-screen flex justify-center p-5 ">
+    <div className="h-screen flex justify-center p-5 text-white ">
       <div className="flex flex-col gap-5 list max-h-screen overflow-y-auto no-scrollbar scroll-smooth">
         <p className="text-center">
           The text describes the results of a test that measures various

--- a/app/about/certificates/page.tsx
+++ b/app/about/certificates/page.tsx
@@ -6,7 +6,7 @@ const CertificatesPage = async () => {
   const certificates: Certificate[] = await getCertificates();
 
   return (
-    <div className="text-white bg-[#2A2A3B] p-0 sm:p-8">
+    <div className="text-white p-0 sm:p-8">
       <div className="max-w-screen-lg mx-auto">
         <div className="grid grid-cols-4 gap-2">
           <div className="col-span-4 lg:col-span-1">
@@ -25,7 +25,7 @@ const CertificatesPage = async () => {
           </div>
         </div>
 
-        <div className="relative flex flex-col gap-7 bg-[#2A2A3B] max-w-screen-lg py-5 mt-5">
+        <div className="relative flex flex-col gap-7 max-w-screen-lg py-5 mt-5">
           {certificates.map((certificate) => (
             <CertificateCard
               key={certificate.slug}

--- a/app/about/jimmy/page.tsx
+++ b/app/about/jimmy/page.tsx
@@ -6,7 +6,7 @@ const page = () => {
   const testDataJimmy = testAboutData.find((data) => data.title == 'Jimmy');
 
   return (
-    <div className="text-white bg-[#2A2A3B] p-0 sm:p-8">
+    <div className="text-white p-0 sm:p-8">
       <div className="max-w-screen-lg mx-auto">
         <div className="grid grid-cols-4 gap-2">
           <div className="col-span-4 lg:col-span-1">

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -1,5 +1,5 @@
 import '../../styles/globals.css';
-import Link from 'next/link';
+import SubLinks from '@/components/SubLinks';
 
 export const metadata = {
   title: 'About',
@@ -36,17 +36,14 @@ export default function AboutLayout({
   return (
     <div className="flex-1 flex flex-col p-10">
       <div className="flex gap-4">
-        <div className="hidden md:flex flex-col gap-4 text-xl  md:rounded-md p-5 bg-[#aaaaaa]">
+        <div className="hidden md:flex flex-col gap-4 text-xl  md:rounded-md bg-[#222222]">
           <ul className="flex flex-1 flex-col gap-5 text-[#ffffff]">
             {routeLinks.map((routeLink) => (
-              <li key={routeLink.linkText}>
-                <Link
-                  href={routeLink.route}
-                  className="cursor-pointer hover:text-gray-600"
-                >
-                  {routeLink.linkText}
-                </Link>
-              </li>
+              <SubLinks
+                key={routeLink.route}
+                route={routeLink.route}
+                linkText={routeLink.linkText}
+              />
             ))}
           </ul>
         </div>

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -11,46 +11,43 @@ export default function AboutLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const routeLinks = [
+    {
+      route: '/about',
+      linkText: 'About',
+    },
+    {
+      route: '/about/jimmy',
+      linkText: 'Jimmy',
+    },
+    {
+      route: '/about/adept',
+      linkText: 'Adept',
+    },
+    {
+      route: '/about/testimonial',
+      linkText: 'Testimonial',
+    },
+    {
+      route: '/about/certificates',
+      linkText: 'Certificates',
+    },
+  ];
   return (
     <div className="flex-1 flex flex-col p-10">
       <div className="flex gap-4">
         <div className="hidden md:flex flex-col gap-4 text-xl  md:rounded-md p-5 bg-[#aaaaaa]">
-          <h2 className="underline underline-offset-4 uppercase">
-            <Link href={'/about'}>About</Link>
-          </h2>
           <ul className="flex flex-1 flex-col gap-5 text-[#ffffff]">
-            <li>
-              <Link
-                href={'/about/jimmy'}
-                className="cursor-pointer hover:text-gray-600"
-              >
-                Jimmy
-              </Link>
-            </li>
-            <li>
-              <Link
-                href={'/about/adept'}
-                className="cursor-pointer hover:text-gray-600"
-              >
-                Adept
-              </Link>
-            </li>
-            <li>
-              <Link
-                href={'/about/testimonial'}
-                className="cursor-pointer hover:text-gray-600"
-              >
-                Testimonial
-              </Link>
-            </li>
-            <li>
-              <Link
-                href={'/about/certificates'}
-                className="cursor-pointer hover:text-gray-600"
-              >
-                Certificates
-              </Link>
-            </li>
+            {routeLinks.map((routeLink) => (
+              <li key={routeLink.linkText}>
+                <Link
+                  href={routeLink.route}
+                  className="cursor-pointer hover:text-gray-600"
+                >
+                  {routeLink.linkText}
+                </Link>
+              </li>
+            ))}
           </ul>
         </div>
         <div className="flex-1 md:rounded-md border-4 border-[#aaaaaa] p-5 overflow">

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -47,9 +47,7 @@ export default function AboutLayout({
             ))}
           </ul>
         </div>
-        <div className="flex-1 md:rounded-md border-4 border-[#aaaaaa] p-5 overflow">
-          {children}
-        </div>
+        <div className="flex-1 md:rounded-md  p-5 overflow">{children}</div>
       </div>
     </div>
   );

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 const about = () => {
   return (
-    <div className="text-white bg-[#2A2A3B] p-0 sm:p-8">
+    <div className="text-white p-0 sm:p-8">
       <div className="max-w-screen-lg mx-auto">
         <div className="grid grid-cols-4 gap-2">
           <div className="col-span-4 lg:col-span-1">

--- a/app/about/testimonial/page.tsx
+++ b/app/about/testimonial/page.tsx
@@ -11,7 +11,7 @@ export type TestimonialType = {
 
 const page = () => {
   return (
-    <section className="bg-[#aaaaaa] h-screen">
+    <section className="h-screen">
       <div className="max-w-6xl px-6 py-10 max-h-screen overflow-y-auto no-scrollbar scroll-smooth">
         <h1 className="text-2xl font-semibold text-[#dddddd] capitalize lg:text-3xl">
           What colleagues saying

--- a/components/SubLinks.tsx
+++ b/components/SubLinks.tsx
@@ -1,0 +1,29 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import React from 'react';
+
+export type Props = {
+  route: string;
+  linkText: string;
+};
+
+const SubLinks = ({ route, linkText }: Props) => {
+  const currentRoute = usePathname();
+  const activeLinkStyle = 'text-orange-600';
+  const currentRouteEndsWith = currentRoute.endsWith(route);
+  return (
+    <li className="">
+      <Link
+        href={route}
+        className={`cursor-pointer ${
+          currentRouteEndsWith && activeLinkStyle
+        } hover:text-orange-600`}
+      >
+        {linkText}
+      </Link>
+    </li>
+  );
+};
+
+export default SubLinks;

--- a/components/SubLinks.tsx
+++ b/components/SubLinks.tsx
@@ -16,9 +16,9 @@ const SubLinks = ({ route, linkText }: Props) => {
     <li className="">
       <Link
         href={route}
-        className={`cursor-pointer ${
+        className={`cursor-pointer text-[#aaaaaa] ${
           currentRouteEndsWith && activeLinkStyle
-        } hover:text-orange-600`}
+        } hover:text-white`}
       >
         {linkText}
       </Link>


### PR DESCRIPTION
| Status  | Type  | Env Vars Change | Review App | Ticket | Issue number
| :---: | :---: | :---: | :--: | :--: | :--: |
| Ready | Bug | No | [test-next-13-jy5r4huk7](https://test-next-13-jy5r4huk7-wongprom.vercel.app/about/certificates) | #35  | #35 

## Problem
When links are in action, their style is missing.
![Skärmavbild 2023-10-13 kl  13 49 01](https://github.com/wongprom/test-next-13/assets/32749038/5ddde4dd-5de7-4821-831a-6902894b4eb3)



## Solution

Solve the issue by changing the link text to orange when it's active.


## Before & After Screenshots

![Skärmavbild 2023-10-13 kl  13 45 47](https://github.com/wongprom/test-next-13/assets/32749038/27edfe21-60c8-4c45-8bb2-fe6ce46fb729)
![Skärmavbild 2023-10-13 kl  13 45 28](https://github.com/wongprom/test-next-13/assets/32749038/14ad1dcd-169d-438f-baf1-6ccc3add0a6b)
![Skärmavbild 2023-10-13 kl  13 45 08](https://github.com/wongprom/test-next-13/assets/32749038/9590f608-be99-412f-9d41-d62331de8e32)
![Skärmavbild 2023-10-13 kl  13 44 44](https://github.com/wongprom/test-next-13/assets/32749038/3f2f71e3-75d6-4e49-a90e-4e3830d563e4)
![Skärmavbild 2023-10-13 kl  13 44 03](https://github.com/wongprom/test-next-13/assets/32749038/26f3ae2d-9ce5-4277-bc20-7512cf3c955f)



## Other changes (e.g. bug fixes, UI tweaks, small refactors)

Jazzing Up the UI: Making It Look Squeaky Clean, One Pixel at a Time! 🪣
- Houdini-style disappearance of the background color ✨
- Text color transformation, like a chameleon changing its spots, when the background color decides to play hide and seek! 🦎🎨

## Checklist

<!---
This checklist is mostly useful as a reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply, make notes next to any that haven't been addressed,
Remove any items that are not relevant to this PR.
-->

General

- [X] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] I have performed a self-review of my code
- [x] My code contains no conflicts and is up to date with the latest main branch
